### PR TITLE
System Scope Rework

### DIFF
--- a/index-1.html
+++ b/index-1.html
@@ -1,0 +1,4 @@
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Unknown </title></head><body>
+<h1 id="bom">bom</h1>
+<p>Visual BOM </p>
+</body></html>

--- a/scanner_releases_list.php
+++ b/scanner_releases_list.php
@@ -8,6 +8,16 @@
 ?>
 <?php
   global $count_err;
+
+
+  function updateScope($db, $newScope)
+  {
+      $sql = "UPDATE scope_preferences
+              SET default_scope = '$newScope'
+              WHERE preference_id = 0;";
+      $result = $db->query($sql);
+  }
+
   /*----------------- SET PREFERENCE COOKIE -----------------*/
   $cookie_name = 'preference';
   $expire = strtotime('+1 year');
@@ -33,6 +43,23 @@
   }elseif(isset($_POST['save']) && !isset($_POST['app'])) {
     if(!isset($apps)) {
       $count_err = "Please select at least one BOM."; 
+    }
+  }elseif(isset($_POST['saveScope'])) {
+    $apps = $_POST['app'];
+
+    if(count($apps) > 5) {
+      $count_err = "You can't select more than 5 BOMS."; 
+
+    }else {
+      echo '<p 
+        style="font-size: 2.5rem; 
+        text-align: center; 
+        background-color: green; 
+        color: white;">Default BOM scope successfully set.</p>';
+        header("Refresh:5");
+      $newScope = implode(",",$apps);
+      updateScope($db, $newScope);
+      
     }
   }
 
@@ -75,6 +102,7 @@
             <th>RTM Date(s)</th>
             <th>Manager</th>
             <th>Author</th>
+            <th>Tag</th>
           </tr>
         </thead>
 
@@ -124,7 +152,8 @@
                 <td>'.$row["freeze_date"].'</td>
                 <td>'.$row["rtm_date"].' </span> </td>
                 <td>'.$row["manager"].' </span> </td>
-                <td>'.$row["author"].' </span> </td>';
+                <td>'.$row["author"].' </span> </td>
+                <td>'.$row["tag"].' </span> </td>';
                 $result2->close();
             }
           }
@@ -144,6 +173,7 @@
               <th>RTM Date(s)</th>
               <th>Manager</th>
               <th>Author</th>
+              <th>Tag</th>
             </tr>
           </tfoot>
         </table>
@@ -154,6 +184,14 @@
           border-radius: 10px;
           padding: 1rem;
           margin-right: 1rem;'>Set My BOMS</button>
+
+        <button type='submit' name='saveScope' value='submit'
+        style='background: #01B0F1;
+          color: white;
+          border: none;
+          border-radius: 10px;
+          padding: 1rem;
+          margin-right: 1rem;'>Set System BOMS</button>
         </form>
         <!-- End preference form -->                       
 

--- a/scanner_sbom_list.php
+++ b/scanner_sbom_list.php
@@ -63,12 +63,12 @@
     global $pdo;
     global $DEFAULT_SCOPE_FOR_RELEASES;
 
-    $sql = "SELECT * FROM releases WHERE tag LIKE ?";
-    foreach($DEFAULT_SCOPE_FOR_RELEASES as $currentTag){
-      $sqlTag = $pdo->prepare($sql);
-      $sqlTag->execute([$currentTag]);
-      if ($sqlTag->rowCount() > 0) {
-        while($row = $sqlTag->fetch(PDO::FETCH_ASSOC)){
+    $sql = "SELECT * FROM releases WHERE app_id LIKE ?";
+    foreach($DEFAULT_SCOPE_FOR_RELEASES as $currentID){
+      $sqlID = $pdo->prepare($sql);
+      $sqlID->execute([$currentID]);
+      if ($sqlID->rowCount() > 0) {
+        while($row = $sqlID->fetch(PDO::FETCH_ASSOC)){
           array_push($scopeArray, $row["app_id"]);
         }
       }
@@ -150,8 +150,7 @@
         if(isset($_POST['getall'])) {
           $def = "false";
           getBoms($db);
-        } //if user clicks "get default BOMS", retrieve BOMS within system scope 
-        elseif (isset($_POST['getdef'])) {
+        } elseif (isset($_POST['getdef'])) {
           $def = "true";
           getBoms($db);
           getFilterArray($db);
@@ -249,7 +248,7 @@
       /* 
       * If the default scope is to be used then this will iterate through
       * each row of the datatable and hide any rows whose app_id does not
-      * match a release who's tag is not in the default scope
+      * match a release who's app is not in the default scope
       */
       
       var def = <?php echo json_encode($def); ?>;
@@ -260,7 +259,7 @@
           function (value, index) {
             var currentID = table.row(value).data()[1];
             var currentIDString = JSON.stringify(currentID);
-            for (var i = 0; i < 3; i++){
+            for (var i = 0; i < app_id.length; i++){
             if (currentIDString.includes(app_id[i])) {
               return false;
               break;

--- a/scanner_sbom_tree.php
+++ b/scanner_sbom_tree.php
@@ -24,12 +24,12 @@
     global $pdo;
     global $DEFAULT_SCOPE_FOR_RELEASES;
 
-    $sql = "SELECT * FROM releases WHERE tag LIKE ?";
-    foreach($DEFAULT_SCOPE_FOR_RELEASES as $currentTag){
-      $sqlTag = $pdo->prepare($sql);
-      $sqlTag->execute([$currentTag]);
-      if ($sqlTag->rowCount() > 0) {
-        while($row = $sqlTag->fetch(PDO::FETCH_ASSOC)){
+    $sql = "SELECT * FROM releases WHERE app_id LIKE ?";
+    foreach($DEFAULT_SCOPE_FOR_RELEASES as $currentID){
+      $sqlID = $pdo->prepare($sql);
+      $sqlID->execute([$currentID]);
+      if ($sqlID->rowCount() > 0) {
+        while($row = $sqlID->fetch(PDO::FETCH_ASSOC)){
           array_push($scopeArray, $row["app_id"]);
         }
       }

--- a/setup.php
+++ b/setup.php
@@ -2,29 +2,7 @@
   $nav_selected = "SETUP";
   $left_buttons = "YES";
   $left_selected = "";
-  $newTag = "";
   include("./nav.php");
-  
-  function updateTags($db)
-{
-    global $newTag;
-    $sql = "UPDATE scope_preferences
-            SET default_scope = '$newTag'
-            WHERE preference_id = 0;";
-    $result = $db->query($sql);
-    echo "You selected $newTag";
-}
-if(isset($_POST['submit']))
-{
-  //If user enters an empty string then set tag to something that will never be used as a tag
-  //Thus entering an empty string ensures that no rows will match during table generation
-   if($_POST["tag"] != ''){
-    $newTag = $_POST["tag"];
-   } else {
-    $newTag = "NO TAG";
-   }
-   updateTags($db);
-} 
  ?>
 
  <div class="right-content">
@@ -34,18 +12,5 @@ if(isset($_POST['submit']))
 
     </div>
 </div>
-
-<html>
-<body>
-Change Scope Preferences <br>
-The scope must be a single string with no spaces or special characters
-other than commas used for delmiting. E.g "active,special,released" <br><br>
-
-<form action="setup.php" method="post">
-Scope: <input type="text" name="tag"><br>
-<input type="submit" value="update" name='submit'>
-</form>
-</body>
-</html>
 
 <?php include("./footer.php"); ?>

--- a/sql updates/RWeikleengetsbom.sql
+++ b/sql updates/RWeikleengetsbom.sql
@@ -1,0 +1,98 @@
+-- phpMyAdmin SQL Dump
+-- version 4.9.2
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: Mar 18, 2020 at 12:53 AM
+-- Server version: 10.4.11-MariaDB
+-- PHP Version: 7.2.26
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `bom`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `sbom`
+--
+
+CREATE TABLE `sbom` (
+  `row_id` int(6) NOT NULL,
+  `app_id` varchar(15) NOT NULL,
+  `app_name` varchar(100) NOT NULL,
+  `app_version` varchar(15) NOT NULL,
+  `cmp_id` varchar(15) NOT NULL,
+  `cmp_name` varchar(100) NOT NULL,
+  `cmp_version` varchar(15) NOT NULL,
+  `cmp_type` varchar(15) NOT NULL,
+  `app_status` varchar(15) NOT NULL,
+  `cmp_status` varchar(15) NOT NULL,
+  `request_id` varchar(15) NOT NULL,
+  `request_date` date NOT NULL,
+  `request_status` varchar(15) NOT NULL,
+  `request_step` varchar(30) NOT NULL,
+  `notes` varchar(100) DEFAULT NULL,
+  `requestor` varchar(100) NOT NULL,
+  `color` varchar(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `sbom`
+--
+
+INSERT INTO `sbom` (`row_id`, `app_id`, `app_name`, `app_version`, `cmp_id`, `cmp_name`, `cmp_version`, `cmp_type`, `app_status`, `cmp_status`, `request_id`, `request_date`, `request_status`, `request_step`, `notes`, `requestor`, `color`) VALUES
+(1, 'BOM-100', 'QuizMaster', '1.1', '101.1', 'DB_Layer', '2.3', 'internal', 'released', 'released', 'PQR_839_R1', '2019-09-02', 'Approved', 'Approval Step', '', '', 'red'),
+(2, 'BOM-100', 'QuizMaster', '1.1', '101.2', 'Jquery', '4.3', 'open source', 'released', 'approved', 'XYZ_789_R2', '2019-10-01', 'Approved', 'Approval Step', 'open source, no commercial support', '', 'yellow'),
+(3, 'BOM-100', 'QuizMaster', '1.1', '101.3', 'Bootstrap', '8.5.c', 'open source', 'released', 'pending', 'ABC_678_R1', '2018-02-12', 'Submitted', 'Inspection Step', '', '', 'yellow'),
+(4, 'BOM-100', 'QuizMaster', '1.1', '101.4', 'IconFinder', '2019', 'commercial', 'released', 'submitted', 'BND_387_R1', '2005-10-15', 'Submitted', 'Inspection Step', '', '', 'yellow'),
+(5, 'BOM-100', 'QuizMaster', '1.1', '101.5', 'Excel', '2019', 'commercial', 'released', 'in_review', 'BSL_887_R2', '2010-06-18', 'Pending', 'Review Step', '', '', 'yellow'),
+(6, '101.1', 'DB_Layer', '2.3', '101.1.1', 'DB_Layer_MySQL', 'v1.0', 'internal', 'released', 'released', 'KSI_887_R3', '2019-10-07', 'Approved', 'Approval Step', '', '', 'green'),
+(8, '101.1', 'DB_Layer', '2.3', '101.1.2', 'DB_Layer_DB2', 'v1.0', 'internal', 'released', 'released', 'KSE_888_R1', '2009-06-10', 'Approved', 'Approval Step', '', '', 'green'),
+(10, '101.1', 'DB_Layer', '2.3', '101.1.4', 'DB_Layer_Ingress', 'v1.0', 'internal', 'released', 'released', 'LSO_262_R2', '2012-05-28', 'Approved', 'Approval Step', '', '', 'green'),
+(11, 'BOM-104', 'QuizMaster', '2.2', '202.2', 'DB_Layer', '2.3', 'internal', 'released', 'released', 'IWU_376_R2', '2007-02-18', 'Approved', 'Approval Step', '', '', 'red'),
+(12, 'BOM-104', 'QuizMaster', '2.2', '202.2', 'Jquery', '4.3', 'open source', 'released', 'approved', 'BLD_198_R1', '2019-06-17', 'Submitted', 'Inspection Step', 'open source, no commercial support', '', 'red'),
+(13, 'BOM-104', 'QuizMaster', '2.2', '202.3', 'Bootstrap', '8.5.c', 'open source', 'released', 'pending', 'KSO_409_R2', '2005-01-30', 'Pending', 'Review Step', '', '', 'yellow'),
+(14, 'BOM-104', 'QuizMaster', '2.2', '202.4', 'IconFinder', '2029', 'commercial', 'released', 'submitted', 'OSP_736_R2', '2019-05-28', 'Submitted', 'Inspection Step', '', '', 'yellow'),
+(15, 'BOM-104', 'QuizMaster', '2.2', '202.5', 'Excel', '2029', 'commercial', 'released', 'in_review', 'NXH_309_R1', '2017-03-01', 'Pending', 'Review Step', '', '', 'yellow'),
+(16, '202.2', 'DB_Layer', '2.3', '202.2.2', 'DB_Layer_Maria', 'v2.0', 'internal', 'released', 'released', 'HSI_735_R2', '2000-07-06', 'Approved', 'Approval Step', '', '', 'green'),
+(17, '202.2', 'DB_Layer', '2.3', '202.2.2', 'DB_Layer_DB2', 'v2.0', 'internal', 'released', 'released', 'SOI_037_R3', '2013-05-13', 'Approved', 'Approval Step', '', '', 'green'),
+(18, '202.2', 'DB_Layer', '2.3', '202.2.3', 'DB_Layer_Oracle', 'v2.0', 'internal', 'released', 'released', 'JSE_398_R1', '2019-06-18', 'Approved', 'Approval Step', '', '', 'green'),
+(19, '202.2', 'DB_Layer', '2.3', '202.2.4', 'DB_Layer_Ingress', 'v2.0', 'internal', 'released', 'released', 'MSI_465_R2', '2004-04-30', 'Approved', 'Approval Step', '', '', 'green'),
+(20, '202.2', 'DB_Layer', '2.3', '202.2.5', 'DB_Layer_MS_SQL', 'v2.0', 'internal', 'released', 'released', 'SPO_765_R3', '2018-04-09', 'Approved', 'Approval Step', '', '', 'green');
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `sbom`
+--
+ALTER TABLE `sbom`
+  ADD PRIMARY KEY (`row_id`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `sbom`
+--
+ALTER TABLE `sbom`
+  MODIFY `row_id` int(6) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=21;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/sql updates/releases.sql
+++ b/sql updates/releases.sql
@@ -1,0 +1,80 @@
+-- phpMyAdmin SQL Dump
+-- version 4.9.2
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: Feb 18, 2020 at 09:59 PM
+-- Server version: 10.4.11-MariaDB
+-- PHP Version: 7.2.26
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `bom`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `releases`
+--
+
+CREATE TABLE `releases` (
+  `id` varchar(10) NOT NULL,
+  `name` varchar(89) DEFAULT NULL,
+  `type` varchar(6) DEFAULT NULL,
+  `status` varchar(9) DEFAULT NULL,
+  `open_date` varchar(10) DEFAULT NULL,
+  `dependency_date` varchar(10) DEFAULT NULL,
+  `content_date` varchar(10) DEFAULT NULL,
+  `rtm_date` varchar(10) DEFAULT NULL,
+  `manager` varchar(14) DEFAULT NULL,
+  `author` varchar(15) DEFAULT NULL,
+  `app_id` varchar(7) DEFAULT NULL,
+  `tag` varchar(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `releases`
+--
+
+INSERT INTO `releases` (`id`, `name`, `type`, `status`, `open_date`, `dependency_date`, `content_date`, `rtm_date`, `manager`, `author`, `app_id`, `tag`) VALUES
+('ICS-201684', 'SAFe Project V.5.6.8', 'Async ', 'Draft', '2020-10-01', '2020-08-23', '2020-10-18', '2020-12-06', 'Brill, Barbara', 'Ram, Christina', 'BOM-107', ''),
+('ICS-201685', 'SAFe Project V.5.6.9', 'Async ', 'Draft', '2021-10-01', '2021-08-23', '2021-10-18', '2021-12-06', 'Brill, Barbara', 'Ram, Christina', 'BOM-112', ''),
+('ICS-201689', 'SAFe Project V.5.6.7', 'Async ', 'Active', '2019-10-01', '2019-08-23', '2019-10-18', '2019-12-06', 'Brill, Barbara', 'Ram, Christina', 'BOM-102', ''),
+('ICS-201812', 'QuizMaster 1.1', 'Major', 'Completed', '2019-08-23', '2019-10-18', '', '2019-08-14', 'Jasthi, Siva', 'Knight, Mark', 'BOM-100', 'active'),
+('ICS-201814', 'QuizMaster 1.2', 'Major', 'Draft', '2020-08-23', '2020-10-18', '', '2020-08-14', 'Jasthi, Siva', 'Knight, Mark', 'BOM-105', 'active'),
+('ICS-201815', 'QuizMaster That Works in English, Telugu, Hindi, Kannada and Other Indic Languages V 2020', 'Major', 'Draft', '2021-08-23', '2021-10-18', '', '2021-08-14', 'Jasthi, Siva', 'Knight, Mark', 'BOM-110', ''),
+('ICS-201944', 'Bingo 2.4', 'Minor', 'Draft', '2020-10-18', '', '', '2020-09-05', 'Doe, John', 'Doe, Jane', 'BOM-106', ''),
+('ICS-201945', 'Bingo 2.3', 'Minor', 'Draft', '2019-10-18', '', '', '2019-09-05', 'Doe, John', 'Doe, Jane', 'BOM-101', ''),
+('ICS-201955', 'Bingo 2.5', 'Minor', 'Draft', '2021-10-18', '', '', '2021-09-05', 'Doe, John', 'Doe, Jane', 'BOM-111', ''),
+('ICS-789084', 'Registration System V.2020', 'Async ', 'Draft', '2020-10-01', '2020-08-23', '2020-10-18', '2020-12-06', 'Drew, Andy', 'Peterson, Rocky', 'BOM-108', ''),
+('ICS-789085', 'Registration System V.2020.1', 'Async ', 'Draft', '2021-10-01', '2021-08-23', '2021-10-18', '2021-12-06', 'Drew, Andy', 'Peterson, Rocky', 'BOM-113', ''),
+('ICS-789089', 'Registration System V.2019', 'Async ', 'Released', '2019-10-01', '2019-08-23', '2019-10-18', '2019-12-06', 'Drew, Andy', 'Peterson, Rocky', 'BOM-103', ''),
+('ICS-898984', 'Word Explorer 2021', 'Patch', 'Draft', '2020-10-01', '2020-08-23', '2020-10-18', '2020-12-06', 'Jasthi, Siva', 'Jasthi, Siva', 'BOM-109', ''),
+('ICS-898985', 'Word Explorer 2022', 'Patch', 'Draft', '2021-10-01', '2021-08-23', '2021-10-18', '2021-12-06', 'Jasthi, Siva', 'Jasthi, Siva', 'BOM-114', ''),
+('ICS-898989', 'Word Explorer 2020', 'Patch', 'Completed', '2019-10-01', '2019-08-23', '2019-10-18', '2019-12-06', 'Jasthi, Siva', 'Jasthi, Siva', 'BOM-104', 'active');
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `releases`
+--
+ALTER TABLE `releases`
+  ADD PRIMARY KEY (`id`);
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
System scope is now set in the releases list. The releases list now shows the tags of the releases. Storage of the system scope has been changed to be a list of app_ids instead of tags to better suit the specifications set by the professor. The setup.php file was reset to it's original version and does not contain any functionality.